### PR TITLE
Adding frame_margin back

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I saw some limits to the approach
 I decided to solve it, and heavily modified the code so it can fix all those problems.
 
 # Differences
-Due to the modifications, you can no longer specify sounded_speed, frame_margin, frame_rate, frame_quality, that is all handled internally. (it also doesn't download youtube videos automatically). I tried to make the code a lot simpler but I'm open to PR request that can still enhance the repo.
+Due to the modifications, you can no longer specify sounded_speed, frame_rate, frame_quality, that is all handled internally. (it also doesn't download youtube videos automatically). I tried to make the code a lot simpler but I'm open to PR request that can still enhance the repo.
 
 PS, if you want sounded speech speedup, I would recommend just speeding up the video on the player.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/seaty6/jumpcutterV2/releases/latest/download/fast_video.exe
 The above is simply the python file compiled with pyinstaller - it should work on Windows without having to install Python, but you will have to install ffmpeg. The easiest way to do this is to install chocolatey and let it do the work for you.
 From an administrative command prompt:
 
-`Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))`
+`@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command " [System.Net.ServicePointManager]::SecurityProtocol = 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"`
 
 Close, then reopen the command prompt, and run:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Python:
 Using shorts:
 `fast_video.exe {video file name} -s {float} -t {float}`
 
-> Note: On Linux and Windows, `python3` doesn't work. Use `python` instead. ALternativly, you could use the executable if on Windows, in the releases tab.
+> Note: On Linux and Windows, `python3` doesn't work. Use `python` instead. Alternatively, you could use the executable if on Windows, in the releases tab.
 # Heads up
 Based on Python3
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,19 @@ Carykh's program: https://github.com/carykh/jumpcutter
 
 # Windows download
 https://github.com/seaty6/jumpcutterV2/releases/latest/download/fast_video.exe
-The above is simply the python file compiled with pyinstaller - it should work on Windows without having to install Python, FFMpeg, or any other dependencies. 
+The above is simply the python file compiled with pyinstaller - it should work on Windows without having to install Python, but you will have to install ffmpeg. The easiest way to do this is to install chocolatey and let it do the work for you.
+From an administrative command prompt:
+
+`Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))`
+
+Close, then reopen the command prompt, and run:
+
+`choco install ffmpeg`
+
+And you're done! You can now run the executable.
 
 # Differences
-1. Can no longer specify:
-  a. sounded_speed
-  b. frame_rate
-  c. frame_quality
+1. Can no longer specify: sounded_speed, frame_rate, and frame_quality.
 2. Can't download youtube videos
 3. Doesn't take up a large amount of space by splitting up each frame
 4. Goes much faster.

--- a/README.md
+++ b/README.md
@@ -1,35 +1,37 @@
 # jumpcutterV2
-automatically edits videos, originally inspired by carykh
+Automatically edits videos - Originally inspired by carykh, then inspired by gusals3587, to be later fixed by WyattBlue.
 
-original inspiration: https://www.youtube.com/watch?v=DQ8orIurGxw
+Carykh's video: https://www.youtube.com/watch?v=DQ8orIurGxw
 
-the program he made: https://github.com/carykh/jumpcutter
-
-I saw some limits to the approach
-1. He extracted EVERY frame and put it into a single, giant folder. While that is easier to work with, it require's GBs, maybe even TBs of free storage.
-2. There were some syncing issues involved if it worked with long videos.
-3. While it was working on the audio, it kept making small, temp audio files that made it very slow.
-
-I decided to solve it, and heavily modified the code so it can fix all those problems.
+Carykh's program: https://github.com/carykh/jumpcutter
 
 # Windows download
 https://github.com/seaty6/jumpcutterV2/releases/latest/download/fast_video.exe
 The above is simply the python file compiled with pyinstaller - it should work on Windows without having to install Python, FFMpeg, or any other dependencies. 
 
 # Differences
-Due to the modifications, you can no longer specify sounded_speed, frame_rate, frame_quality, that is all handled internally. (it also doesn't download youtube videos automatically). I tried to make the code a lot simpler but I'm open to PR request that can still enhance the repo.
+1. Can no longer specify:
+  a. sounded_speed
+  b. frame_rate
+  c. frame_quality
+2. Can't download youtube videos
+3. Doesn't take up a large amount of space by splitting up each frame
+4. Goes much faster.
 
-PS, if you want sounded speech speedup, I would recommend just speeding up the video on the player.
+
 
 # Usage
+
+
+Windows:
+`fast_video.exe {video file name} --silentSpeed {float} --silentThreshold {float}`
+
+Python:
 `python3 fast_video.py {video file name} --silentSpeed {float} --silentThreshold {float}`
 
 Using shorts:
-
-`python3 fast_video.py {video file name} -s {float} -t {float}`
+`fast_video.exe {video file name} -s {float} -t {float}`
 
 > Note: On Linux and Windows, `python3` doesn't work. Use `python` instead. ALternativly, you could use the executable if on Windows, in the releases tab.
-# heads up
-I've only tested this with mp4 file, not sure about other formats.
-
-I also use python3, not planning any backward compatibility.
+# Heads up
+Based on Python3

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ I saw some limits to the approach
 
 I decided to solve it, and heavily modified the code so it can fix all those problems.
 
+# Windows download
+https://github.com/seaty6/jumpcutterV2/releases/latest/download/fast_video.exe
+The above is simply the python file compiled with pyinstaller - it should work on Windows without having to install Python, FFMpeg, or any other dependencies. 
+
 # Differences
 Due to the modifications, you can no longer specify sounded_speed, frame_rate, frame_quality, that is all handled internally. (it also doesn't download youtube videos automatically). I tried to make the code a lot simpler but I'm open to PR request that can still enhance the repo.
 
@@ -24,7 +28,7 @@ Using shorts:
 
 `python3 fast_video.py {video file name} -s {float} -t {float}`
 
-> Note: On Linux and Windows, `python3` doesn't work. Use `python` instead.
+> Note: On Linux and Windows, `python3` doesn't work. Use `python` instead. ALternativly, you could use the executable if on Windows, in the releases tab.
 # heads up
 I've only tested this with mp4 file, not sure about other formats.
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,9 @@ The above is simply the python file compiled with pyinstaller - it should work o
 3. Doesn't take up a large amount of space by splitting up each frame
 4. Goes much faster.
 
-
-
 # Usage
-
-
 Windows:
 `fast_video.exe {video file name} --silentSpeed {float} --silentThreshold {float}`
-
 Python:
 `python3 fast_video.py {video file name} --silentSpeed {float} --silentThreshold {float}`
 
@@ -35,3 +30,7 @@ Using shorts:
 > Note: On Linux and Windows, `python3` doesn't work. Use `python` instead. ALternativly, you could use the executable if on Windows, in the releases tab.
 # Heads up
 Based on Python3
+
+# Credits:
+Thanks to https://github.com/gusals3587/jumpcutterV2 for reworking the code to be much more optimized
+Thanks to https://github.com/WyattBlue/jumpcutterV2 for adding back the all but the frame_margin parameter


### PR DESCRIPTION
it's now possible to use the parameter "frame_margin" again by splitting the audiochunk matrix into two. Also updated frequency of frames inspected text for slower computers